### PR TITLE
Updates instructions to use Reserve DOI

### DIFF
--- a/ZenodoBestPractices.md
+++ b/ZenodoBestPractices.md
@@ -13,24 +13,33 @@ Update: zenodo began supporting versioning on May 30, 2018. Please see their blo
 
 ## Executive Summary
 
-This document has three parts:
+This document has five parts:
+* **Things You Should Know**.  Words of caution and advice.
 * **Creating Web hooks**. Create a zenodo entry automatically when issuing a new release.
 * **Manual Upload**.  Uploading older versions of software packages or other files and datasets.
 * **Metadata**. Guidelines for assigning metadata.
+* **Save or Publish**. Once Publish'ed, you cannot add to or delete uploaded files.
 
 ## Things You Should Know
 
-Once your files have been uploaded and assigned a DOI the submission CANNOT BE CHANGED. You will not be able to add more files or edit the existing files.
+Once your files have been uploaded and Publish'ed, the submission CANNOT BE CHANGED. You will not be able to add more files or edit the existing files. Save the record instead if you might upload additional files.
 
-You CAN edit the metadata.
+You CAN still edit the metadata after Publishing.
+
+If you embed the software DOI in the documentation (_recommended_), you can reserve a DOI.  On the upload page under Basic Information and Digital Object Identifier click the _Reserve DOI_ button. This will not register the DOI, nor will it publish your record so you can still update the files. See Zenodo FAQs under _General_ for more information: [help.zenodo.org](https://help.zenodo.org/)
+
+
+Don't forget to add the DOI to the GitHub release!
+* Clicking on the DOI badge on the Zenodo page will present copyable Markdown text (and other formats) that can be placed in the GitHub release text to display the badge on GitHub.
 
 ## Creating Web Hooks
- 
-By creating a webhook into your repository, a zenodo entry will automatically be created with each new release. If versioned from a previous entry, the versions will be automatically associated. 
+
+By creating a webhook into your repository, a zenodo entry will automatically be created with each new release. If versioned from a previous entry, the versions will be automatically associated.
 
 You will still need to:
-* assign your code to the CIG community
-* check your authors lists especially if all commit'ters are not considered authors for your project
+* Assign your code to the CIG community.
+* Check your authors lists especially if all committers are not considered authors for your project.
+* If you embed the software DOI into your documentation, you must reserve the DOI first, update your documentation, and then create the release.
 
 Please see the github guide: https://guides.github.com/activities/citable-code/
 
@@ -46,50 +55,56 @@ Please check records to ensure that metadata is correct.
    * Use your GitHub or ORCID account or create a new login. Using GitHub will automatically associate it with your repository.
 2. **Create**
    * Click on "Upload" on the browser header (between search bar and *Communities*).
-   1. _**Adding a New Package**_
-      * Click on the "New Upload" button on upper right hand side of the page.
-   2. _**Adding a New Version to an Existing Package**_
-      * Select the package from your Uploads directory. Click on "New Version".
 
-At any time, you can select an uploaded package and edit its metadata. However, you CANNOT change the package's files without creating a new version.
+    A. _**Adding a New Package**_
+      * Click on the _New Upload_ button on upper right hand side of the page.
 
-3. **Upload**
+    B. _**Adding a New Version to an Existing Package**_
+      * Select the package from your Uploads directory. Click on _New Version_.
+3. **Reserve a DOI**
+      * Under Basic Information -> Digital Object Identifier click the _Reserve DOI_ button.
+
+4. **Upload**
    * Drag and drop your files into the window or choose files as directed.
 
-Then proceed to the Metadata section.
+
+
+Proceed to the Metadata section.
 
 ## Metadata
 
-Please use the following guidelines when assigning metadata. 
+Please use the following guidelines when assigning metadata.
 
 1. **Upload type**
-   * Please assign "software" to all github releases.  There is a known BUG in the the display of this metadata field when viewing. In the citation field, this displays as "Data Set". Zenodo promises it will be fixed in the next release.
+   * Please assign _software_ to all github releases.  
 2. **Basic Information**
    * Add the mandatory data.
-   * Reserve a DOI only when you are sure you are not changing, adding or deleting to the uploaded files.
-   * Authors. WEBHOOK USERS: When generating a zenodo release using a webhook, the default is to assign all commit'ers as authors.  Default behaviors can be overridden using .zenodo.json file in the main directory. See PyLith and ASPECT for examples.
+   * Authors. WEBHOOK USERS: When generating a zenodo release using a webhook, the default is to assign all commiters as authors.  Default behaviors can be overridden using .zenodo.json file in the main directory. See PyLith and ASPECT for examples.
    * Description.  Please add an informative description of the software and changes to this release.  This is what the user will see.
-   * Additional Notes. Add acknowledgements including funding here.
+   * Additional Notes. Add acknowledgements including funding here if your grant cannot be found in 5.
 3. **License**
-   * All CIG codes are "Open Access"
-   * Please search for the correct "License". Most CIG codes are "GNU General Pubic License 2.0".
+   * All CIG codes are _Open Access_
+   * Please search for the correct _License_. Most CIG codes are _GNU General Pubic License 2.0_ or _GNU General Pubic License 3.0_. _or later_ is also supported.
 4. **Communities**
-   * Please assign the community "Computational Infrastructure for Geodynamics". Sometimes you need to type in most of the string before zenodo finds it.
+   * Please assign the community "Computational Infrastructure for Geodynamics". You may need to type in most of the string before zenodo finds it.
 5. **Funding**
-   * Choose from pick list of European and Australian funding agencies and NSF to add funding acknowledgements. If your grant is not listed, add it in *Additional Notes*.
+   * Choose from pick list of funding agencies to add funding acknowledgements. NSF grants are now supported. If your grant is not listed, add it in *Additional Notes*. See 2.
 6. **Related/alternate identifiers**
-   * Add geodyanmics.org/software/*CodeName* as "references this upload"
-   * Add the github repo e.g. https://github.com/geodynamics/aspect/tree/v1.5.0 as "is a supplement to this upload"
+   * Add geodynamics.org/software/*CodeName* as _references this upload_.
+   * Add the github repo e.g. https://github.com/geodynamics/aspect/tree/v1.5.0 as _is a supplement to this upload_.
 7. **Contributors**
    * Please don't forget to acknowledge others who contributed to this research product.
 8. **References**
    * Add references you want users to cite here.
 9. **Journal, Conference, Book/Report/Chapter, Thesis**
    * If this research product is part of one of the above, add the reference here.
- 
+
+## Save or Publish
 When you are ready do not forget to **Publish** or just remember to **Save** your work.
 
-Once you have published the release to Zenodo, a new DOI will be minted. Don't forget to add the DOI to the GitHub release!
-* Clicking on the DOI badge on the Zenodo page will present copiable Markdown text (and other formats) that can be placed in the GitHub release text to display the badge on GitHub.
+* Save your work if you anticipate modifying the uploaded files.
+* At any time, you can select an uploaded package and edit its metadata.
+* Once Published, the DOI is minted and you CANNOT change the package's files without creating a new version.
+
 
 Please feel free to add to these instructions.

--- a/ZenodoBestPractices.md
+++ b/ZenodoBestPractices.md
@@ -22,11 +22,11 @@ This document has five parts:
 
 ## Things You Should Know
 
-Once your files have been uploaded and Publish'ed, the submission CANNOT BE CHANGED. You will not be able to add more files or edit the existing files. Save the record instead if you might upload additional files.
+Once your files have been uploaded and _Publish_'ed, the submission CANNOT BE CHANGED. You will not be able to add more files or edit the existing files. Save the record instead if you might upload additional files.
 
 You CAN still edit the metadata after Publishing.
 
-If you embed the software DOI in the documentation (_recommended_), you can reserve a DOI.  On the upload page under Basic Information and Digital Object Identifier click the _Reserve DOI_ button. This will not register the DOI, nor will it publish your record so you can still update the files. See Zenodo FAQs under _General_ for more information: [help.zenodo.org](https://help.zenodo.org/)
+If you embed the software DOI in the documentation (_recommended_), you can reserve a DOI before publishing.  On the upload page under Basic Information and Digital Object Identifier click the _Reserve DOI_ button. This will not register the DOI, nor will it publish your record so you can still update the files in your repository. See Zenodo FAQs under _General_ for more information: [help.zenodo.org](https://help.zenodo.org/)
 
 
 Don't forget to add the DOI to the GitHub release!
@@ -39,7 +39,7 @@ By creating a webhook into your repository, a zenodo entry will automatically be
 You will still need to:
 * Assign your code to the CIG community.
 * Check your authors lists especially if all committers are not considered authors for your project.
-* If you embed the software DOI into your documentation, you must reserve the DOI first, update your documentation, and then create the release.
+* If you embed the software DOI into your documentation, DO NOT USE this feature in conjunction with _Reserve DOI_.
 
 Please see the github guide: https://guides.github.com/activities/citable-code/
 


### PR DESCRIPTION
The major conceptual change is to add instructions to use the _Reserve DOI_ feature in Zenodo. 

Other updates:
* Includes spelling and typesetting corrections.
* Is redundant, purposefully, to emphasize the difference between _Save_ and _Publish_.
* Moves text around so the flow is better.
* Updates to text to reflect recent bug fixes and new features in Zenodo.

This should be updated with a better understanding of how webhooks work with _Reserve DOI_.